### PR TITLE
Criteria improvements

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject stowaway "0.1.21"
+(defproject stowaway "0.1.22-SNAPSHOT"
   :description "Library for abstracting data storage from business logic"
   :url "https://github.com/dgknght/stowaway"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/test/stowaway/criteria_test.clj
+++ b/test/stowaway/criteria_test.clj
@@ -139,11 +139,9 @@
 
 (deftest apply-a-fn-to-criteria
   (let [f (fn [m]
-            (if (contains? m :user/name)
-              (update-in m
+            (c/update-in m
                          [:user/name]
-                         #(str/lower-case %))
-              m))]
+                         #(str/lower-case %)))]
     (is (= {:user/name "john"}
            (c/apply-to {:user/name "JoHn"}
                        f))
@@ -159,4 +157,7 @@
           "The fn is applied to maps within the vector")
       (is (= {:testing true}
              (meta x))
-          "The metadata is preserved"))))
+          "The metadata is preserved"))
+    (is (= {:user/name [:>= "john"]}
+           (c/apply-to {:user/name [:>= "JoHn"]} f))
+        "The fn is applied to values within an operation vector")))


### PR DESCRIPTION
add `stowaway.criteria/update-in` to handle updates to criterion values that include an explicit operator, like `{:user/age [:>= 21]}`.