### PR TITLE
datalog reverse references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+# Stowaway
+
+This is a library that facilitates data persistance.
+
+## Technicals
+
+- Clojure
+- Targets relational databases and Datomic databases.
+
+## Commands
+
+- `lein test` - Run the test suite
+- `clj-kondo --lint src:test` - Run the linter

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject stowaway "0.2.13-SNAPSHOT"
+(defproject stowaway "0.2.13"
   :description "Library for abstracting data storage from business logic"
   :url "https://github.com/dgknght/stowaway"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject stowaway "0.2.12"
+(defproject stowaway "0.2.13-SNAPSHOT"
   :description "Library for abstracting data storage from business logic"
   :url "https://github.com/dgknght/stowaway"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/stowaway/datalog.clj
+++ b/src/stowaway/datalog.clj
@@ -189,13 +189,15 @@
   the most restrictive clauses first. To achieve this, put entities higher in
   the relationship hierarchy first."
   [{:keys [relationships graph-apex graph] :as ctx}]
-  (let [entities (->> relationships seq flatten set)
-        shortest #(shortest-path graph graph-apex %)
-        input-vars (set (concat (get-in ctx [:query :in]) (:inputs ctx)))
-        sorter (clause->sortable shortest entities (assoc ctx :input-vars input-vars))]
-    (update-in ctx
-               [:query :where]
-               (partial sort-by sorter))))
+  (if (-> ctx :query :where seq)
+    (let [entities (->> relationships seq flatten set)
+          shortest #(shortest-path graph graph-apex %)
+          input-vars (set (concat (get-in ctx [:query :in]) (:inputs ctx)))
+          sorter (clause->sortable shortest entities (assoc ctx :input-vars input-vars))]
+      (update-in ctx
+                 [:query :where]
+                 (partial sort-by sorter)))
+    ctx))
 
 (defmulti ^:private criterion->inputs
   (fn [[_ v]]
@@ -611,6 +613,19 @@
       (assoc-in ctx [:query :find] attrs)
       (update-in ctx [:query :find] concat attrs))))
 
+(defn- pull-clause?
+  [x]
+  (and (list? x)
+       (= 3 (count x))
+       (= 'pull (first x))))
+
+(defn- append-pull-attrs
+  [clause attrs]
+  ; e.g., (pull ?x [*]) -> (pull ?x [* :transaction/_items])
+  (let [ref (nth clause 1)
+        existing (nth clause 2)]
+    (list 'pull ref (vec (concat existing attrs)))))
+
 (defn- apply-select-to-pull
   "When :pull is present, add the attributes to the :find
   clause within the vector of attributes in `(pull ?x [*])`."
@@ -619,10 +634,9 @@
     (update-in ctx
                [:query :find]
                (fn [f]
-                 (map (fn [v]
-                        (if (and (list? v)
-                                 (= 'pull (first v)))
-                          (apply list (concat v pull))
+                 (mapv (fn [v]
+                        (if (pull-clause? v)
+                          (append-pull-attrs v pull)
                           v))
                       f)))
     ctx))
@@ -633,19 +647,21 @@
            target]
     :or {entity-ref '?x}
     :as ctx}]
-  (update-in ctx
-             [:query :where]
-             concat
-             (->> select
-                  (remove #(= :id %))
-                  (map (comp (replace-nil ctx)
-                             #(let [n (namespace %)]
-                                (vector (if (= target (keyword n))
-                                          entity-ref
-                                          (symbol (str "?" n)))
-                                        %
-                                        (attr-ref % ctx))))))
-             (extract-joining-clauses-from-attributes select ctx)))
+  (if (seq select)
+    (update-in ctx
+               [:query :where]
+               concat
+               (->> select
+                    (remove #(= :id %))
+                    (map (comp (replace-nil ctx)
+                               #(let [n (namespace %)]
+                                  (vector (if (= target (keyword n))
+                                            entity-ref
+                                            (symbol (str "?" n)))
+                                          %
+                                          (attr-ref % ctx))))))
+               (extract-joining-clauses-from-attributes select ctx))
+    ctx))
 
 (defn- extract-select-inputs
   [{:keys [select nil-replacements query] :as ctx}]
@@ -670,12 +686,13 @@
                                     (filter #(and (= (name (first %))
                                                      (name attr))
                                                   (= (name (second %))
-                                                     (namespace attr)))))]
+                                                     (namespace attr))))
+                                    first)]
       (keyword (name parent)
                (str "_"
                     (name (or alias child)))))))
 
-(defn- separate-directly-linked
+(defn- separate-reverse-linked-entities
   "Remove the :select list into attributes that can be reached
   from the target via a reverse relationship and put them in
   a list at :pull"
@@ -698,11 +715,15 @@
 
 (defn- apply-select-to-args
   [{:as ctx :keys [args]}]
-  (update-in ctx [:query :args] (fnil concat []) args))
+  (if (seq args)
+    (update-in ctx [:query :args] (fnil concat []) args)
+    ctx))
 
 (defn- apply-select-to-in
   [{:as ctx :keys [inputs]}]
-  (update-in ctx [:query :in] (fnil concat []) inputs))
+  (if (seq inputs)
+    (update-in ctx [:query :in] (fnil concat []) inputs)
+    ctx))
 
 (s/def ::select (s/or :scalar keyword?
                       :vector (s/coll-of keyword?)))
@@ -728,7 +749,7 @@
       infer-target
       calculate-graph
       map-hints
-      separate-directly-linked
+      separate-reverse-linked-entities
       extract-select-inputs
       apply-select-to-pull
       apply-select-to-find

--- a/src/stowaway/datalog.clj
+++ b/src/stowaway/datalog.clj
@@ -611,6 +611,22 @@
       (assoc-in ctx [:query :find] attrs)
       (update-in ctx [:query :find] concat attrs))))
 
+(defn- apply-select-to-pull
+  "When :pull is present, add the attributes to the :find
+  clause within the vector of attributes in `(pull ?x [*])`."
+  [{:as ctx :keys [pull]}]
+  (if (seq pull)
+    (update-in ctx
+               [:query :find]
+               (fn [f]
+                 (map (fn [v]
+                        (if (and (list? v)
+                                 (= 'pull (first v)))
+                          (apply list (concat v pull))
+                          v))
+                      f)))
+    ctx))
+
 (defn- apply-select-to-where
   [{:keys [select
            entity-ref
@@ -647,6 +663,39 @@
            :inputs inputs
            :args args)))
 
+(defn- ->inverse-rel
+  [relationships]
+  (fn [attr]
+    (let [[parent child alias] (->> relationships
+                                    (filter #(and (= (name (first %))
+                                                     (name attr))
+                                                  (= (name (second %))
+                                                     (namespace attr)))))]
+      (keyword (name parent)
+               (str "_"
+                    (name (or alias child)))))))
+
+(defn- separate-directly-linked
+  "Remove the :select list into attributes that can be reached
+  from the target via a reverse relationship and put them in
+  a list at :pull"
+  [{:as ctx :keys [select target relationships]}]
+  ; The only reason to do this is to select an attribute
+  ; from an entity with the relationship is defined on the 
+  ; related entity and not the target
+  (let [entities (->> relationships
+                      (filter #(= target (second %)))
+                      (map (comp name first))
+                      set)
+        {:keys [slct pull]} (group-by (fn [k]
+                                        (if (entities (name k))
+                                          :pull
+                                          :select))
+                                      select)]
+    (assoc ctx
+           :select slct
+           :pull (map (->inverse-rel relationships) pull))))
+
 (defn- apply-select-to-args
   [{:as ctx :keys [args]}]
   (update-in ctx [:query :args] (fnil concat []) args))
@@ -679,7 +728,9 @@
       infer-target
       calculate-graph
       map-hints
+      separate-directly-linked
       extract-select-inputs
+      apply-select-to-pull
       apply-select-to-find
       apply-select-to-where
       apply-select-to-in

--- a/src/stowaway/datalog.clj
+++ b/src/stowaway/datalog.clj
@@ -682,15 +682,18 @@
 (defn- ->inverse-rel
   [relationships]
   (fn [attr]
-    (let [[parent child alias] (->> relationships
-                                    (filter #(and (= (name (first %))
+    (let [[primary-entity
+           referring-entity
+           alias]
+          (->> relationships
+                                    (filter #(and (= (name (second %))
                                                      (name attr))
-                                                  (= (name (second %))
+                                                  (= (name (first %))
                                                      (namespace attr))))
                                     first)]
-      (keyword (name parent)
+      (keyword (name referring-entity)
                (str "_"
-                    (name (or alias child)))))))
+                    (name (or alias primary-entity)))))))
 
 (defn- separate-reverse-linked-entities
   "Remove the :select list into attributes that can be reached
@@ -698,11 +701,11 @@
   a list at :pull"
   [{:as ctx :keys [target relationships]}]
   ; The only reason to do this is to select an attribute
-  ; from an entity with the relationship is defined on the 
+  ; from an entity when the relationship is defined on the 
   ; related entity and not the target
   (let [entities (->> relationships
-                      (filter #(= target (second %)))
-                      (map (comp name first))
+                      (filter #(= target (first %)))
+                      (map (comp name second))
                       set)
         {:keys [select pull]} (group-by (fn [k]
                                         (if (entities (name k))

--- a/src/stowaway/datalog.clj
+++ b/src/stowaway/datalog.clj
@@ -696,7 +696,7 @@
   "Remove the :select list into attributes that can be reached
   from the target via a reverse relationship and put them in
   a list at :pull"
-  [{:as ctx :keys [select target relationships]}]
+  [{:as ctx :keys [target relationships]}]
   ; The only reason to do this is to select an attribute
   ; from an entity with the relationship is defined on the 
   ; related entity and not the target
@@ -704,14 +704,14 @@
                       (filter #(= target (second %)))
                       (map (comp name first))
                       set)
-        {:keys [slct pull]} (group-by (fn [k]
+        {:keys [select pull]} (group-by (fn [k]
                                         (if (entities (name k))
                                           :pull
                                           :select))
-                                      select)]
+                                      (:select ctx))]
     (assoc ctx
-           :select slct
-           :pull (map (->inverse-rel relationships) pull))))
+           :select (vec select)
+           :pull (mapv (->inverse-rel relationships) pull))))
 
 (defn- apply-select-to-args
   [{:as ctx :keys [args]}]

--- a/test/stowaway/datalog_test.clj
+++ b/test/stowaway/datalog_test.clj
@@ -615,13 +615,12 @@
               :transaction/memo]
              {:relationships #{[:transaction :transaction-item]}}))
         "Multiple additional select columns can be specified")
-    (is (= '{:find [(pull ?x [* :transaction/_items])]
-             :in [?a]
-             :args [101]}
+    (is (= '{:find [(pull ?x [* :transaction/_items])]}
            (dtl/apply-select
-             (assoc q :find '[(pull ?x)])
+             '{:find [(pull ?x [*])]}
              [:transaction-item/transaction]
-             {:relationships #{[:transaction :transaction-item :items]}})))))
+             {:relationships #{[:transaction :transaction-item :items]}
+              :target :transaction-item})))))
 
 (deftest apply-select-sorts-where-clauses
   (let [q (merge query '{:where [[?x :transaction-item/account ?a]]

--- a/test/stowaway/datalog_test.clj
+++ b/test/stowaway/datalog_test.clj
@@ -619,7 +619,7 @@
            (dtl/apply-select
              '{:find [(pull ?x [*])]}
              [:transaction-item/transaction]
-             {:relationships #{[:transaction :transaction-item :items]}
+             {:relationships #{[:transaction-item :transaction :items]}
               :target :transaction-item})))))
 
 (deftest apply-select-sorts-where-clauses

--- a/test/stowaway/datalog_test.clj
+++ b/test/stowaway/datalog_test.clj
@@ -550,7 +550,7 @@
   (let [q (merge query '{:where [[?x :transaction-item/account ?a]]
                          :in [?a]
                          :args [101]})]
-    #_(is (= '{:find [?quantity]
+    (is (= '{:find [?quantity]
              :where [[?x :transaction-item/account ?a]
                      [?x :transaction-item/quantity ?quantity]]
              :in [?a]
@@ -560,7 +560,7 @@
              :transaction-item/quantity
              {:replace true}))
         "The entire select clause can be specified as an attribute")
-    #_(is (= '{:find [?x]
+    (is (= '{:find [?x]
              :where [[?x :transaction-item/account ?a]]
              :in [?a]
              :args [101]}
@@ -569,7 +569,7 @@
              :id
              {:replace true}))
         "The select clause can reference the entity/id")
-    #_(is (= '{:find [?my-entity]
+    (is (= '{:find [?my-entity]
              :where [[?my-entity :transaction-item/account ?a]]
              :in [?a]
              :args [101]}
@@ -579,7 +579,7 @@
              {:replace true
               :entity-ref '?my-entity}))
         "The select clause can reference the id with a custom entity reference")
-    #_(is (= '{:find [?quantity ?value]
+    (is (= '{:find [?quantity ?value]
              :where [[?x :transaction-item/account ?a]
                      [?x :transaction-item/quantity ?quantity]
                      [?x :transaction-item/value ?value]]
@@ -591,7 +591,7 @@
               :transaction-item/value]
              {:replace true}))
         "The entire select clause can be specified as a list of attributes")
-    #_(is (= '{:find [?x ?transaction-date]
+    (is (= '{:find [?x ?transaction-date]
              :where [[?x :transaction-item/account ?a]
                      [?x :transaction-item/transaction ?transaction]
                      [?transaction :transaction/transaction-date ?transaction-date]]
@@ -602,7 +602,7 @@
              :transaction/transaction-date
              {:relationships #{[:transaction :transaction-item]}}))
         "An additional select column can be specified from another model")
-    #_(is (= '{:find [?x ?description ?memo]
+    (is (= '{:find [?x ?description ?memo]
              :where [[?x :transaction-item/account ?a]
                      [?x :transaction-item/transaction ?transaction]
                      [?transaction :transaction/description ?description]

--- a/test/stowaway/datalog_test.clj
+++ b/test/stowaway/datalog_test.clj
@@ -550,7 +550,7 @@
   (let [q (merge query '{:where [[?x :transaction-item/account ?a]]
                          :in [?a]
                          :args [101]})]
-    (is (= '{:find [?quantity]
+    #_(is (= '{:find [?quantity]
              :where [[?x :transaction-item/account ?a]
                      [?x :transaction-item/quantity ?quantity]]
              :in [?a]
@@ -560,7 +560,7 @@
              :transaction-item/quantity
              {:replace true}))
         "The entire select clause can be specified as an attribute")
-    (is (= '{:find [?x]
+    #_(is (= '{:find [?x]
              :where [[?x :transaction-item/account ?a]]
              :in [?a]
              :args [101]}
@@ -569,7 +569,7 @@
              :id
              {:replace true}))
         "The select clause can reference the entity/id")
-    (is (= '{:find [?my-entity]
+    #_(is (= '{:find [?my-entity]
              :where [[?my-entity :transaction-item/account ?a]]
              :in [?a]
              :args [101]}
@@ -579,7 +579,7 @@
              {:replace true
               :entity-ref '?my-entity}))
         "The select clause can reference the id with a custom entity reference")
-    (is (= '{:find [?quantity ?value]
+    #_(is (= '{:find [?quantity ?value]
              :where [[?x :transaction-item/account ?a]
                      [?x :transaction-item/quantity ?quantity]
                      [?x :transaction-item/value ?value]]
@@ -591,7 +591,7 @@
               :transaction-item/value]
              {:replace true}))
         "The entire select clause can be specified as a list of attributes")
-    (is (= '{:find [?x ?transaction-date]
+    #_(is (= '{:find [?x ?transaction-date]
              :where [[?x :transaction-item/account ?a]
                      [?x :transaction-item/transaction ?transaction]
                      [?transaction :transaction/transaction-date ?transaction-date]]
@@ -602,7 +602,7 @@
              :transaction/transaction-date
              {:relationships #{[:transaction :transaction-item]}}))
         "An additional select column can be specified from another model")
-    (is (= '{:find [?x ?description ?memo]
+    #_(is (= '{:find [?x ?description ?memo]
              :where [[?x :transaction-item/account ?a]
                      [?x :transaction-item/transaction ?transaction]
                      [?transaction :transaction/description ?description]
@@ -614,7 +614,14 @@
              [:transaction/description
               :transaction/memo]
              {:relationships #{[:transaction :transaction-item]}}))
-        "Multiple additional select columns can be specified")))
+        "Multiple additional select columns can be specified")
+    (is (= '{:find [(pull ?x [* :transaction/_items])]
+             :in [?a]
+             :args [101]}
+           (dtl/apply-select
+             (assoc q :find '[(pull ?x)])
+             [:transaction-item/transaction]
+             {:relationships #{[:transaction :transaction-item :items]}})))))
 
 (deftest apply-select-sorts-where-clauses
   (let [q (merge query '{:where [[?x :transaction-item/account ?a]]


### PR DESCRIPTION
When using `(pull ?x [*])`, it's possible to fetch the id of another entity that references the `?x` entity, like `(pull ?x [* :transaction/_items])`.